### PR TITLE
Add plugin + config to exclude binaries from resource filtering

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,17 @@
                     </compilerArgs>
                 </configuration>
             </plugin>
+            <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>3.2.0</version>
+                    <configuration>
+                        <!-- Add excluded extensions to be filetered here-->
+                        <nonFilteredFileExtensions>
+                            <nonFilteredFileExtension>jks</nonFilteredFileExtension>
+                        </nonFilteredFileExtensions>
+                    </configuration>
+                </plugin>
         </plugins>
 	</build>
 


### PR DESCRIPTION
Need to add an exclude for binaries
https://maven.apache.org/plugins/maven-resources-plugin/examples/binaries-filtering.html

Related to issue:
https://github.com/mulesoft-catalyst/api-template-mule4.x/issues/2